### PR TITLE
6: Resolve promise before sending it back

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-bro",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ export default class ApiBro {
             }
             fetch(path, request)
                 .then(
-                    (res) => res.ok ? resolve(res.json()) : reject(res.json()),
+                    (res) => res.ok ? res.json().then(resolve) : res.json().then(reject),
                     (error) => reject(error)
                 )
                 .catch((error) => reject(error))


### PR DESCRIPTION
resolve the promise before returning the object, otherwise you end up with a promise back from your request instead of the resolved item in some scenarios